### PR TITLE
use of sha1 was deprecated

### DIFF
--- a/chainer.rb
+++ b/chainer.rb
@@ -4,7 +4,7 @@ class Chainer < Formula
   url 'https://github.com/pfnet/chainer/archive/v1.0.0.tar.gz'
   head 'https://github.com/pfnet/chainer.git', :using => :git
   homepage 'http://chainer.org/'
-  sha1 'cb5eb5defd116013f275a5852105b71b3db07387'
+  sha256 '6f63507614b45c3fc6b25bdba26c9780887403f260986ccbaa408823ce2ee919'
   version '1.0.0'
 
   option 'enable-cuda', 'Enable CUDA for nVidia-GPU-mounted Mac'


### PR DESCRIPTION
On Homebrew 1.1.6, I confirm the tapping failure as follow.
```
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/pfnet/homebrew-chainer/chainer.rb
Calling Formula.sha1 is disabled!
Use Formula.sha256 instead.
/usr/local/Homebrew/Library/Taps/pfnet/homebrew-chainer/chainer.rb:7:in `<class:Chainer>'
Please report this to the pfnet/chainer tap!
Error: Cannot tap pfnet/chainer: invalid syntax in tap!
```

Use of sha1 was deprecated already, so you should replace sha1 with sha256.
- https://github.com/Homebrew/homebrew-core/issues/6693